### PR TITLE
set lines to 0 to avoid increment in number of lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ lines() {
     # 'read' exits with '1' when it sees EOL and
     # without the added test, the line isn't sent
     # to the loop.
+    lines=0
     while IFS= read -r line || [ -n "$line" ]; do
         lines=$((lines+1))
     done < "$1"


### PR DESCRIPTION
Hi @dylanaraps,

I've fixed a bug in lines() by setting the lines variable to 0 as it was incrementing the number of lines if you call lines multiple times.

For example:

`$ lines /path/to/file.txt`
`$ 100`
`$ lines /path/to/file.txt`
`$ 200`
 