### PR TITLE
Reduce side effects of string functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ without leading/trailing white-space and with truncated spaces.
 trim_all() {
     # Usage: trim_all "   example   string    "
 
+    # Save the current shell options, so we can
+    # restore them later.
+    options=$-
+
     # Disable globbing to make the word-splitting below safe.
     set -f
 
@@ -186,8 +190,9 @@ trim_all() {
     # Print the argument list as a string.
     printf '%s\n' "$*"
 
-    # Re-enable globbing.
-    set +f
+    # Restore the original shell options.
+    # "${options##*f*}": Empty if '$options' contains 'f'
+    [ -n "${options##*f*}" ] && set +f
 }
 ```
 
@@ -270,6 +275,10 @@ This is an alternative to `cut`, `awk` and other tools.
 
 ```sh
 split() {
+    # Save the current shell options, so we can
+    # restore them later.
+    options=$-
+
     # Disable globbing.
     # This ensures that the word-splitting is safe.
     set -f
@@ -296,8 +305,9 @@ split() {
     # Restore the value of 'IFS'.
     IFS=$old_ifs
 
-    # Re-enable globbing.
-    set +f
+    # Restore the original shell options.
+    # "${options##*f*}": Empty if '$options' contains 'f'
+    [ -n "${options##*f*}" ] && set +f
 }
 ```
 
@@ -325,6 +335,10 @@ $ split "1, 2, 3, 4, 5" ", "
 ```sh
 trim_quotes() {
     # Usage: trim_quotes "string"
+
+    # Save the current shell options, so we can
+    # restore them later.
+    options=$-
 
     # Disable globbing.
     # This makes the word-splitting below safe.
@@ -355,8 +369,9 @@ trim_quotes() {
     # Restore the value of 'IFS'.
     IFS=$old_ifs
 
-    # Re-enable globbing.
-    set +f
+    # Restore the original shell options.
+    # "${options##*f*}": Empty if '$options' contains 'f'
+    [ -n "${options##*f*}" ] && set +f
 }
 ```
 


### PR DESCRIPTION
Some of the string functions have the side effect of changing shell options&mdash;in particular enabling shell globbing. For example if you disable shell globbing with `set -f` and run, say, `trim_all "  example   string    "`, you will find that shell globbing has been re-enabled without your asking.

This patches some (or all?) of those functions to restore shell options before they end.

I have tested this carefully, but shell can be tricky to work with so it's possible I've made a mistake somewhere.