### PR TITLE
Differentiate touch and truncate

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,15 +502,26 @@ $ count ~/Pictures/*.jpg
 64
 ```
 
-## Create an empty file
+## Create or truncate a file
 
-Alternative to `touch`.
+Alternative to `truncate -s0`.
 
 ```shell
 :>file
 
 # OR (shellcheck warns for this)
 >file
+```
+
+## Create or update modification time of a file
+
+Alternative to `touch`.
+
+```shell
+:>>file
+
+# OR (shellcheck warns for this)
+>>file
 ```
 
 # FILE PATHS


### PR DESCRIPTION
Since `:>file` can potentially destroy important data, I think this is an important distinction to make. But I'm not sure this is the neatest way to do it. It might be better just to have a note reminding readers that `>` overwrite files completely.