### PR TITLE
Fix a bug in lines() (after a year of its discovery!)

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ lines() {
     done < "$1"
 
     printf '%s\n' "$lines"
+    unset lines
 }
 ```
 


### PR DESCRIPTION
Some time ago, about a year ago, i've discovered a bug at `lines()` when [incorporating it in a Shell library of mine](https://github.com/takusuman/otto-pkg/blob/master/usr.lib/otto/posix-alt.shi).
Basically, when you ran it for the first time, it stored a integer with the number of lines in the `${lines}` variable, which is the expected.
But, when you ran it for the second time, it started adding the value of `${lines}`, from the first run, with the value of the current run.

The fix to this is very simple, just add `unset` at the end of the function, so it removes the old value from the memory and them add the new.

I had been wanting to do a pull request for a while to fix this, but i've ran out of time and ended up forgetting about it.

I hope it helps now.