### PR TITLE
Add function to find substring at the beginning of a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,27 @@ case $var in
 esac
 ```
 
+**Using printf builtin:**
+
+**Example function:**
+
+```sh
+startswith() {
+
+    if [ "$(printf "%.${#1}s" "$2")" = "$1" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+```
+
+**Example usage:**
+
+```sh
+$ startswith 'fo' 'foo'
+```
+
 ## Check if string ends with sub-string
 
 **Using a case statement:**


### PR DESCRIPTION
`printf` precision and `%s` conversion [specifications](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/printf.html) can be used to limit the [bytes/characters](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_84) written from a string. To take advantage of
this we can use the if compound command, `test` builtin command, command substitution, and parameter expansion to compare the beginning of a string and a substring.

```shell
if [ "$(printf "%.${#substring}s" "${string}")" = "${substring}" ]; then
    printf 'Starts with\n'
else
    printf 'Does not start with\n'
fi
```

It does not really matter if a parameter is empty or unset, because its length will be zero and identical strings will be compared.

> ...a null digit string is treated as zero.

*From*: [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap05.html#tag_05)

```shell
# Both are empty
string=''
substring=''

# '' and '' are compared
if [ "$(printf "%.${#substring}s" "${string}")" = "${substring}" ]; then
    printf 'Starts with\n'
else
    printf 'Does not start with\n'
fi
```

I have executed the test shell script without errors and tested the code against many strings.

```shell
#!/usr/bin/env dash

startswith() {

    if [ "$(printf "%.${#1}s" "$2")" = "$1" ]; then
        return 0
    else
        return 1
    fi
}

startswith "$1" "$2"
```

*Requires* `zsh` >= 5.9:

```shell
for i in {1..10175}; do char="$(printf "\U$(( [##16]i ))")"; ./startswith "${char}" "${char}"; done
```

```shell
for i in {1..10175}; do char="$(printf "\U$(( [##16]i ))")"; ./startswith "${char}" "${char}oooooooooo"; done
```

The same approach (although more convoluted) can used to find substrings at the end:

```shell
string=foo
substring=oo

if [ "${string#$(printf "%.$(( "${#string}" - "${#substring}" ))s" "${str}")}" = "${substr}" ]; then
    printf 'Ends with\n'
else
    printf 'Does not end with\n'
fi
```
